### PR TITLE
Parse the user from the event if it is passed as an object

### DIFF
--- a/lib/pybot_slack/adapter.py
+++ b/lib/pybot_slack/adapter.py
@@ -58,9 +58,8 @@ class SlackAdapter(Adapter):
                 continue
 
             # Ignore any events sent by the bot
-            user_id = event.get('user')
-            user = self._find_user(user_id)
-            if user_id and user_id == self.bot_id:
+            user = self._user_from_event(event)
+            if user and user.id == self.bot_id:
                 continue
 
             message = None
@@ -84,6 +83,15 @@ class SlackAdapter(Adapter):
 
         # TODO: chat threads
         return Message(user, channel_id, text, ts)
+
+    def _user_from_event(self, event):
+        user = event.get('user')
+        if isinstance(user, dict):
+            # In certain events, the user value of the event
+            # will be the entire user instead of an ID.
+            user = user.get('id')
+
+        return self._find_user(user)
 
     def _send_message(self, channel_id, text):
         self.client.rtm_send_message(channel_id, text)


### PR DESCRIPTION
This is the main reason Fred dies so much. Sometimes slack will send a user id in the user field and other times they will send the entire object (depends on the event type). If we notice that user is an object, we'll grab the id off of it to do the lookup.

Here is an example stack trace for reference.

```
Oct 11 02:01:45 localhost run.py[2553]: Traceback (most recent call last):
Oct 11 02:01:45 localhost run.py[2553]:   File "/var/www/slackbot/run.py", line 15, in <module>
Oct 11 02:01:45 localhost run.py[2553]:     robot.run()
Oct 11 02:01:45 localhost run.py[2553]:   File "/usr/local/lib/python2.7/dist-packages/pybot/robot.py", line 23, in run
Oct 11 02:01:45 localhost run.py[2553]:     self.adapter.run()
Oct 11 02:01:45 localhost run.py[2553]:   File "/usr/local/lib/python2.7/dist-packages/pybot_slack/adapter.py", line 35, in run
Oct 11 02:01:45 localhost run.py[2553]:     self._loop_forever()
Oct 11 02:01:45 localhost run.py[2553]:   File "/usr/local/lib/python2.7/dist-packages/pybot_slack/adapter.py", line 41, in _loop_forever
Oct 11 02:01:45 localhost run.py[2553]:     self._dispatch(events)
Oct 11 02:01:45 localhost run.py[2553]:   File "/usr/local/lib/python2.7/dist-packages/pybot_slack/adapter.py", line 62, in _dispatch
Oct 11 02:01:45 localhost run.py[2553]:     user = self._find_user(user_id)
Oct 11 02:01:45 localhost run.py[2553]:   File "/usr/local/lib/python2.7/dist-packages/pybot_slack/adapter.py", line 92, in _find_user
Oct 11 02:01:45 localhost run.py[2553]:     return self.client.server.users.find(name_or_id)
Oct 11 02:01:45 localhost run.py[2553]:   File "/usr/local/lib/python2.7/dist-packages/slackclient/_util.py", line 23, in find
Oct 11 02:01:45 localhost run.py[2553]:     user = self.get(search_string)
Oct 11 02:01:45 localhost run.py[2553]: TypeError: unhashable type: 'dict'
```

As a note for the future: we'll want this main dispatch loop to be resilient to failures. An exception inside the loop should not cause the bot to crash; similar to an HTTP server or any long-running process, it should log loudly instead.